### PR TITLE
Fix PHP 8.4 deprecation: empty return in MetadataCast::set()

### DIFF
--- a/src/Casts/MetadataCast.php
+++ b/src/Casts/MetadataCast.php
@@ -34,7 +34,7 @@ class MetadataCast implements CastsAttributes
         if (! $model->exists) {
             $model->queuedMetadata = [$key => $value];
 
-            return;
+            return $value;
         }
 
         $model->setMetadata($key, $value);


### PR DESCRIPTION
## Summary
Fixes PHP 8.4 deprecation issue reported in #20 where `MetadataCast::set()` method returns empty value despite having a `string` return type annotation.

## Changes
- Fixed empty return statement on line 37 to return `$value` instead
- Ensures consistent return behavior for both code paths in the method

## Test plan
- Verify that the method now properly returns the value in all scenarios
- Confirm PHP 8.4 compatibility

Fixes #20